### PR TITLE
feat: add legacy hash authentication support

### DIFF
--- a/src/Traits/User/AuthenticatableTrait.php
+++ b/src/Traits/User/AuthenticatableTrait.php
@@ -2,6 +2,8 @@
 
 namespace Tnt\Account\Traits\User;
 
+use Oak\Config\Facade\Config;
+
 /**
  * Trait providing default implementation for AuthenticatableInterface.
  */
@@ -43,7 +45,7 @@ trait AuthenticatableTrait
 
     /**
      * Set the user's password using secure hashing.
-     * 
+     *
      * Only hashes the password if it's not already hashed to prevent double hashing.
      *
      * @param string $password The new password to set
@@ -51,7 +53,15 @@ trait AuthenticatableTrait
      */
     public function setPassword(string $password): self
     {
-        // Check if password is already hashed (password_hash creates strings starting with $)
+        $useLegacyHash = Config::get('accounts.use_legacy_hash', false);
+
+        if ($useLegacyHash) {
+            $this->password_salt = \dry\util\string\random(10);
+            $this->password = md5($password . $this->password_salt);
+
+            return $this;
+        }
+
         if (!$this->isPasswordHashed($password)) {
             $this->password = password_hash($password, PASSWORD_BCRYPT);
         } else {
@@ -63,7 +73,7 @@ trait AuthenticatableTrait
 
     /**
      * Check if a password string is already hashed.
-     * 
+     *
      * @param string $password The password string to check
      * @return bool True if already hashed, false otherwise
      */
@@ -101,4 +111,3 @@ trait AuthenticatableTrait
         return 'password';
     }
 }
-

--- a/src/UserRepository.php
+++ b/src/UserRepository.php
@@ -3,6 +3,7 @@
 namespace Tnt\Account;
 
 use dry\db\FetchException;
+use Oak\Config\Facade\Config;
 use Tnt\Account\Contracts\User\UserInterface;
 use Tnt\Account\Contracts\UserRepositoryInterface;
 use Tnt\Dbi\BaseRepository;
@@ -10,6 +11,7 @@ use Tnt\Dbi\Contracts\CriteriaCollectionInterface;
 use Tnt\Dbi\Criteria\Equals;
 use Tnt\Dbi\Criteria\GreaterThan;
 use Tnt\Dbi\Criteria\IsTrue;
+use Tnt\Dbi\Raw;
 
 /**
  * Repository for managing user data operations.
@@ -61,6 +63,25 @@ class UserRepository extends BaseRepository implements UserRepositoryInterface
                     $authIdentifier
                 )
             );
+
+            $useLegacyHash = Config::get('accounts.use_legacy_hash', false);
+
+            if ($useLegacyHash) {
+                try {
+                    $this->addCriteria(
+                        new Equals(
+                            new Raw('MD5( CONCAT( ?, password_salt ) )', [
+                                $password,
+                            ]),
+                            new Raw('password')
+                        )
+                    );
+
+                    return $this->first();
+                } catch (FetchException $e) {
+                    return null;
+                }
+            }
 
             $user = $this->first();
 
@@ -123,9 +144,8 @@ class UserRepository extends BaseRepository implements UserRepositoryInterface
      * @param string $refreshToken The refresh token to search for
      * @return UserInterface|null The user if found with valid token, null otherwise
      */
-    public function withValidRefreshToken(
-        string $refreshToken
-    ): ?UserInterface {
+    public function withValidRefreshToken(string $refreshToken): ?UserInterface
+    {
         try {
             $this->addCriteria(new Equals('refresh_token', $refreshToken));
             $this->addCriteria(


### PR DESCRIPTION
- Add configurable legacy MD5+salt hashing alongside secure password_hash
- Support legacy authentication in UserRepository with MD5 verification
- Maintain backward compatibility with existing secure hashing